### PR TITLE
Bug report template update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -37,7 +37,7 @@ body:
       required: true
 
   - type: input
-    id: Translate You-version
+    id: Translate_You-version
     attributes:
       label: Translate You version
       description: |

--- a/fastlane/metadata/android/fr-rFR/changelogs/6.txt
+++ b/fastlane/metadata/android/fr-rFR/changelogs/6.txt
@@ -1,0 +1,3 @@
+* Traduisez le texte en le sélectionnant ou en le partageant avec Translate You
+* Correction de problèmes majeurs lors du changement de prestataire de traduction
+* Traduction en français par @Ilithy <3


### PR DESCRIPTION
- The bug report template had a tiny problem preventing users from opening a bug report easily _(my bad)_, this is fixed.

![Screenshot_20221010-084738](https://user-images.githubusercontent.com/36798218/194811223-926dd109-4311-4692-b1b7-836929bfb7d8.jpg)


![Screenshot_20221010-084703](https://user-images.githubusercontent.com/36798218/194811220-49fd6d64-0da2-43bb-986a-ce7b46dd9710.jpg)

- I also created and filled the changelog number 6 in french version (sorry to add it like this, it's really not elegant, and I apologize).

