### PR TITLE
feat: add Kagi Translate support (closes #499)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 * <a href="https://en.pons.com/translate">PONS®</a>
 * <a href="https://glosbe.com/">Glosbe®</a>
 * <a href="https://laratranslate.com/translate">LaraTranslate®</a>
+* <a href="https://translate.kagi.com">Kagi Translate®</a>
 
 <!-- ---------- Screenshots [Plus version] ---------- -->
 ## Screenshots

--- a/app/src/main/java/com/bnyro/translate/api/kagi/Kagi.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/Kagi.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi
+
+import com.bnyro.translate.api.kagi.obj.KagiLanguage
+import com.bnyro.translate.api.kagi.obj.KagiTranslationRequest
+import com.bnyro.translate.api.kagi.obj.KagiTranslationResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface Kagi {
+    @POST("api/translate")
+    suspend fun translate(
+        @Query("token") token: String,
+        @Body request: KagiTranslationRequest
+    ): KagiTranslationResponse
+    
+    @GET("api/list-languages")
+    suspend fun getLanguages(): List<KagiLanguage>
+} 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/KagiEngine.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/KagiEngine.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi
+
+import com.bnyro.translate.api.kagi.obj.KagiTranslationRequest
+import com.bnyro.translate.const.ApiKeyState
+import com.bnyro.translate.db.obj.Language
+import com.bnyro.translate.obj.Definition
+import com.bnyro.translate.obj.Translation
+import com.bnyro.translate.util.RetrofitHelper
+import com.bnyro.translate.util.TranslationEngine
+
+/**
+ * Kagi Translate API implementation
+ *
+ * Requires a session token for authentication
+ */
+class KagiEngine : TranslationEngine(
+    name = "Kagi",
+    defaultUrl = "https://translate.kagi.com",
+    urlModifiable = false,
+    apiKeyState = ApiKeyState.REQUIRED,
+    autoLanguageCode = "auto",
+    // don't touch these values, the code must be adapted when changing!
+    supportedEngines = listOf(
+        "Fastest model",
+        "Fastest model with definitions",
+        "Best model",
+        "Best model with definitions",
+    )
+) {
+    private lateinit var api: Kagi
+
+    override fun createOrRecreate(): TranslationEngine = apply {
+        api = RetrofitHelper.createApi(this)
+    }
+
+    override suspend fun getLanguages(): List<Language> {
+        return api.getLanguages().map { kagiLang ->
+            Language(
+                code = kagiLang.language.lowercase(),
+                name = kagiLang.name
+            )
+        }
+    }
+
+    override suspend fun translate(query: String, source: String, target: String): Translation {
+        val fetchDefinitions = getSelectedEngine().contains("definitions")
+        val useBestModel = getSelectedEngine().contains("Best")
+
+        val request = KagiTranslationRequest(
+            text = query,
+            sourceLang = sourceOrAuto(source),
+            targetLang = target,
+            skipDefinition = !fetchDefinitions,
+            model = if (useBestModel) "best" else null
+        )
+
+        val response = api.translate(
+            token = getApiKey(), // Session token as query parameter
+            request = request
+        )
+
+        return Translation(
+            translatedText = response.translation,
+            detectedLanguage = response.detectedLanguage?.iso,
+            definitions = response.definition?.let { def ->
+                val primaryDefinition = def.primaryMeaning?.let { primary ->
+                    Definition(
+                        type = primary.partOfSpeech.joinToString(", "),
+                        definition = primary.definition,
+                        example = def.examples.firstOrNull()
+                    )
+                }
+
+                val secondaryDefinitions = def.secondaryMeanings.map { secondary ->
+                    Definition(
+                        type = secondary.partOfSpeech.joinToString(", "),
+                        definition = secondary.definition
+                    )
+                }
+
+                (listOfNotNull(primaryDefinition) + secondaryDefinitions)
+                    .takeIf { it.isNotEmpty() }
+            },
+            similar = response.definition?.let { def ->
+                val synonyms =
+                    def.primaryMeaning?.synonyms.orEmpty() + def.secondaryMeanings.flatMap { it.synonyms }
+
+                synonyms.distinct().takeIf { it.isNotEmpty() }
+            },
+            examples = response.definition?.examples?.ifEmpty { null }
+        )
+    }
+} 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiDefinition.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiDefinition.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi.obj
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KagiDefinition(
+    val word: String = "",
+    val language: String = "",
+    @SerialName("part_of_speech") val partOfSpeech: List<String> = emptyList(),
+    @SerialName("usage_level") val usageLevel: List<String> = emptyList(),
+    @SerialName("primary_meaning") val primaryMeaning: KagiMeaning? = null,
+    @SerialName("secondary_meanings") val secondaryMeanings: List<KagiMeaning> = emptyList(),
+    val examples: List<String> = emptyList(),
+    val pronunciation: String? = null,
+    val etymology: String? = null,
+    @SerialName("usage_notes") val usageNotes: List<String> = emptyList(),
+    @SerialName("image_prompt") val imagePrompt: String? = null
+)
+
+@Serializable
+data class KagiMeaning(
+    val definition: String = "",
+    @SerialName("part_of_speech") val partOfSpeech: List<String> = emptyList(),
+    val synonyms: List<String> = emptyList(),
+    val dialect: List<String> = emptyList(),
+    @SerialName("usage_note") val usageNote: String? = null,
+    @SerialName("usage_level") val usageLevel: List<String> = emptyList()
+) 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiDetectedLanguage.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiDetectedLanguage.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi.obj
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KagiDetectedLanguage(
+    val iso: String = "",
+    val label: String = ""
+) 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiLanguage.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiLanguage.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi.obj
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KagiLanguage(
+    val language: String,
+    val name: String,
+    @SerialName("supports_formality") val supportsFormality: Boolean
+) 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationRequest.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationRequest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi.obj
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KagiTranslationRequest(
+    val text: String,
+    @SerialName("source_lang") val sourceLang: String,
+    @SerialName("target_lang") val targetLang: String,
+    @SerialName("skip_definition") val skipDefinition: Boolean = false,
+    val model: String? = null
+) 

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationResponse.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationResponse.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 You Apps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.bnyro.translate.api.kagi.obj
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KagiTranslationResponse(
+    val translation: String = "",
+    @SerialName("detected_language") val detectedLanguage: KagiDetectedLanguage? = null,
+    val definition: KagiDefinition? = null
+) 

--- a/app/src/main/java/com/bnyro/translate/const/TranslationEngines.kt
+++ b/app/src/main/java/com/bnyro/translate/const/TranslationEngines.kt
@@ -21,6 +21,7 @@ import com.bnyro.translate.api.ap.ApEngine
 import com.bnyro.translate.api.deepl.DeeplAuthenticatedEngine
 import com.bnyro.translate.api.deepl.DeeplBrowserEngine
 import com.bnyro.translate.api.gl.GlEngine
+import com.bnyro.translate.api.kagi.KagiEngine
 import com.bnyro.translate.api.la.LaEngine
 import com.bnyro.translate.api.lt.LTEngine
 import com.bnyro.translate.api.lv.LVEngine
@@ -38,6 +39,7 @@ object TranslationEngines {
         LVEngine(),
         DeeplAuthenticatedEngine(),
         DeeplBrowserEngine(),
+        KagiEngine(),
         MMEngine(),
         YandexEngine(),
         STEngine(),

--- a/app/src/main/java/com/bnyro/translate/ui/views/EnginePref.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/views/EnginePref.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bnyro.translate.R
+import com.bnyro.translate.api.kagi.KagiEngine
 import com.bnyro.translate.const.ApiKeyState
 import com.bnyro.translate.const.TranslationEngines
 import com.bnyro.translate.ext.capitalize
@@ -90,9 +91,7 @@ fun EnginePref() {
             EditTextPreference(
                 preferenceKey = engine.apiPrefKey,
                 value = apiKey,
-                labelText = stringResource(
-                    id = R.string.api_key
-                ) + when (engine.apiKeyState) {
+                labelText = stringResource(id = R.string.api_key) + when (engine.apiKeyState) {
                     ApiKeyState.REQUIRED -> " (${stringResource(R.string.required)})"
                     ApiKeyState.OPTIONAL -> " (${stringResource(R.string.optional)})"
                     else -> ""


### PR DESCRIPTION
Hey there! I work at [Kagi](https://kagi.com/), specifically on Kagi Translate. I came across issue #499 while browsing GitHub, so I figured I'd go ahead and create a quick PR to add support myself :)

A quick note:
While Kagi Translate can be used for free/"authless" (just requires passing a turnstile captcha), this implementation requires a Kagi Search session token for authentication. However, a session token from a free account works perfectly fine for this purpose, so I felt this was the most straightforward approach. Let me know if you'd prefer to do things differently.