### PR TITLE
fix: Correct text direction in translation fields

### DIFF
--- a/app/src/main/java/com/bnyro/translate/ui/components/StyledTextField.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/components/StyledTextField.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -62,7 +63,7 @@ fun StyledTextField(
                 )
             }
         },
-        textStyle = textStyle.copy(color = textColor)
+        textStyle = textStyle.copy(color = textColor, textDirection = TextDirection.Content)
     )
 }
 


### PR DESCRIPTION
There was a issue in how we handle right-to-left (RTL) and left-to-right (LTR) text. For example, if you translated something into Arabic, it would still be aligned to the left. If you changed the app's language to Arabic, the English text you were translating from would incorrectly align to the right.

I updated the `StyledTextField` composable to use `textDirection = TextDirection.Content` This tells the text field to automatically set its direction based on the language of the text inside it. This ensures both the source and translated text always have the correct alignment, no matter what the app's language is.

**How to Test?**

1. Keep your app in English.
2. Translate something into Arabic.
3. Check: The translated Arabic text should now be right-aligned.
4. Now, change the app's language to Arabic.
5. Type something in English in the input box.
6. Check: The English text should stay left-aligned, even though the rest of the app is RTL.