### PR TITLE
fix: app crashes on huawei devices

### DIFF
--- a/translation-engines/src/main/java/net/youapps/translation_engines/ap/ApEngine.kt
+++ b/translation-engines/src/main/java/net/youapps/translation_engines/ap/ApEngine.kt
@@ -38,12 +38,16 @@ class ApEngine(settingsProvider: EngineSettingsProvider): TranslationEngine(sett
         api = RetrofitHelper.createApi(this)
     }
 
-    private val iso3ToIso2Map = Locale.getAvailableLocales().associate {
-        it.isO3Language to it.language
+    private val iso3ToIso2Map: Map<String, String> by lazy {
+        Locale.getISOLanguages().associate { iso2 ->
+            Locale.forLanguageTag(iso2).isO3Language to iso2
+        }
     }
 
-    private val iso2ToIso3Map = Locale.getAvailableLocales().associate {
-        it.language to it.isO3Language
+    private val iso2ToIso3Map: Map<String, String> by lazy {
+        Locale.getISOLanguages().associateWith { iso2 ->
+            Locale.forLanguageTag(iso2).isO3Language
+        }
     }
 
     override suspend fun getLanguages(): List<Language> {


### PR DESCRIPTION
Problem: #560

The crash was caused by the ISO mapping in the Apertium engine, where the Locale.getAvailableLocales() function may return non standard locales ('zz' on some Huawei devices), which caused the app to crash.

In my solution I used the Locale.getISOLanguages() function which returns the standard ISO codes, instead of device locales, which should avoid invalid locales on different devices.