### PR TITLE
Resize screen when the keyboard opens

### DIFF
--- a/app/src/main/java/com/bnyro/translate/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/screens/HistoryScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -91,7 +92,8 @@ fun HistoryScreen(
 
     Scaffold(
         modifier = Modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .imePadding(),
         topBar = {
             SearchAppBar(
                 title = stringResource(id = titleId),

--- a/app/src/main/java/com/bnyro/translate/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/screens/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -99,7 +100,8 @@ fun SettingsScreen(
 
     Scaffold(
         modifier = Modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .imePadding(),
         topBar = {
             LargeTopAppBar(
                 title = {

--- a/app/src/main/java/com/bnyro/translate/ui/screens/TranslationPage.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/screens/TranslationPage.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -90,7 +91,9 @@ fun TranslationPage(
 
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState)
         },


### PR DESCRIPTION
Automatically resizes the screen when the keyboard opens, mainly so you can change language with open keyboard.
I implemented on the HistoryScreen, SettingScreen, TranslationPage
This also solves #557

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6fc7329c-3b78-4c01-8522-bb8a502eec4c" />
